### PR TITLE
fix!: support bundlers like webpack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,9 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 21
+          - 24
+          - 22
           - 20
-          - 18
-          - 16
         os:
           - ubuntu-latest
           # - macos-latest

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-brightgreen.svg)](https://conventionalcommits.org)
 
-This library makes it easy to sign response cookie values and authenticate request cookie values using a shared secret. Although the intent is to handle cookie values for your application, this library doesn't work directly with a request or response headers, and it can be used for signing/authenticating any simple strings.
+This library makes it easy to sign response cookie values and authenticate request cookie values using a shared secret. Although the intent is to handle cookie values for your application, this library doesn't work directly with request or response headers, and it can be used for signing/authenticating any simple strings.
 
 This is a rewrite of the original [`cookie-signature` package](https://www.npmjs.com/package/cookie-signature) that uses the [`SubtleCrypto`](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto) standard of the modern [Web Crypto API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API) instead of the [Node.js-specific `crypto` module](https://nodejs.org/dist/latest/docs/api/crypto.html), for better compatibility with runtimes like [Vercel's Edge Runtime](https://vercel.com/docs/functions/edge-functions/edge-runtime). It shares the same API contract as `cookie-signature` except that the methods are asynchronous (returning a `Promise`) instead of synchronous, due to the nature of the `SubtleCrypto` API.
 

--- a/index.js
+++ b/index.js
@@ -9,11 +9,13 @@ async function getWebCrypto () {
     // console.log('Loaded globalThis.crypto.webcrypto')
     return (_crypto = globalThis.crypto.webcrypto) // Node 15/16/18 (repl)
   }
+  /*
   const x = await import('node:crypto')
   if (x.webcrypto) {
     // console.log('Loaded import(\'node:crypto\').webcrypto')
     return (_crypto = x.webcrypto) // Node 15/16/18 (non-repl)
   }
+  */
   throw new Error('Your runtime does not provide a WebCrypto library.')
 }
 
@@ -28,11 +30,13 @@ async function getBuffer () {
     // console.log('Loaded atob/btoa from globalThis')
     return (_buffer = globalThis) // browser
   }
+  /*
   const x = await import('node:buffer')
   if (x.btoa) {
     // console.log('Loaded atob/btoa from import(\'node:buffer\')')
     return (_buffer = x)
   }
+  */
   throw new Error('Your runtime does not provide an impl for atob/btoa.')
 }
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "index.js"
   ],
   "engines": {
-    "node": ">=15.13.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "lint": "standard",


### PR DESCRIPTION
Avoid bundler build-time errors like this:

```
Failed to compile.

node:crypto
Module build failed: UnhandledSchemeError: Reading from "node:crypto" is not handled by plugins (Unhandled scheme).
Webpack supports "data:" and "file:" URIs by default.
You may need an additional plugin to handle "node:" URIs.

Import trace for requested module:
node:crypto
./node_modules/cookie-signature-subtle/index.js
```

**BREAKING CHANGE**: No longer compatible with Node.js versions below 20