### PR TITLE
feat: add TypeScript definitions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,18 @@ jobs:
         run: npm run lint
       - name: Run Tests
         run: npm t
+
+  test-bun:
+    name: Bun on ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ">=1.1.0"
+      - name: Install Dependencies
+        run: bun install
+      - name: Run Tests
+        run: bun test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,4 +46,4 @@ jobs:
       - name: Install Dependencies
         run: bun install
       - name: Run Tests
-        run: bun test
+        run: bun test --coverage

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           registry-url: 'https://registry.npmjs.org'
         if: ${{ steps.release.outputs.release_created }}
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,33 +8,33 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write  # Required for npm Trusted Publishers (OIDC)
 
 jobs:
   release-please:
-    name: Create or Update PR
+    name: Release PR, Publish to NPM
     runs-on: ubuntu-latest
     steps:
-      - name: Run release-please
+      - uses: googleapis/release-please-action@v4
         id: release
-        uses: google-github-actions/release-please-action@v3
         with:
           release-type: node
-          package-name: cookie-signature-subtle
-          default-branch: master
-      # - name: Checkout Code for Publish
-      #   uses: actions/checkout@v4
-      #   if: ${{ steps.release.outputs.release_created }}
-      # - name: Setup Node for Publish
-      #   uses: actions/setup-node@v3
-      #   with:
-      #     node-version: 20
-      #     registry-url: 'https://registry.npmjs.org'
-      #   if: ${{ steps.release.outputs.release_created }}
-      # - name: Install Dependencies for Publish
-      #   run: npm i --ignore-scripts
-      #   if: ${{ steps.release.outputs.release_created }}
-      # - name: Publish to npm
-      #   run: npm publish
-      #   env:
-      #     NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-      #   if: ${{ steps.release.outputs.release_created }}
+          target-branch: master
+
+      - uses: actions/checkout@v4
+        if: ${{ steps.release.outputs.release_created }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: 'https://registry.npmjs.org'
+        if: ${{ steps.release.outputs.release_created }}
+
+      - run: npm install --ignore-scripts
+        if: ${{ steps.release.outputs.release_created }}
+
+      - run: npm test
+        if: ${{ steps.release.outputs.release_created }}
+
+      - run: npm publish --provenance
+        if: ${{ steps.release.outputs.release_created }}

--- a/_bun.test.js
+++ b/_bun.test.js
@@ -1,0 +1,147 @@
+import { test, expect } from 'bun:test'
+import cs, { CookieSignature } from './index.js'
+
+test('singleton.sign(valueToSign, secret) should sign the cookie', async () => {
+  const signed = await cs.sign('hello', 'tobiiscool')
+  expect(signed).toBe('hello.DGDUkGlIkCzPz+C0B064FNgHdEjox7ch8tOBGslZ5QI')
+
+  const signed2 = await cs.sign('hello', 'luna')
+  expect(signed2).not.toBe('hello.DGDUkGlIkCzPz+C0B064FNgHdEjox7ch8tOBGslZ5QI')
+})
+
+test('singleton.sign(valueToSign, secret) should accept appropriately non-string secrets', async () => {
+  const signed = await cs.sign('hello', Buffer.from('A0ABBC0C', 'hex'))
+  expect(signed).toBe('hello.hIvljrKw5oOZtHHSq5u+MlL27cgnPKX77y7F+x5r1to')
+
+  expect(cs.sign('unsupported', new Date())).rejects.toThrow(TypeError)
+})
+
+test('singleton.unsign(signedCookieValue, secret) should unsign the cookie', async () => {
+  const signed = await cs.sign('hello', 'tobiiscool')
+
+  const unsigned = await cs.unsign(signed, 'tobiiscool')
+  expect(unsigned).toBe('hello')
+
+  const unsigned2 = await cs.unsign(signed, 'luna')
+  expect(unsigned2).toBe(false)
+})
+
+test('singleton.unsign(signedCookieValue, secret) should reject malformed cookies', async () => {
+  const secret = 'actual sekrit password'
+
+  const unsigned = await cs.unsign('fake unsigned data', secret)
+  expect(unsigned).toBe(false)
+
+  const signed = await cs.sign('real data', secret)
+  const unsigned2 = await cs.unsign('garbage' + signed, secret)
+  expect(unsigned2).toBe(false)
+
+  const unsigned3 = await cs.unsign('garbage.' + signed, secret)
+  expect(unsigned3).toBe(false)
+
+  const unsigned4 = await cs.unsign(signed + '.garbage', secret)
+  expect(unsigned4).toBe(false)
+
+  const unsigned5 = await cs.unsign(signed + 'garbage', secret)
+  expect(unsigned5).toBe(false)
+})
+
+test('singleton.unsign(signedCookieValue, secret) should accept non-string secrets', async () => {
+  const key = Uint8Array.from([0xA0, 0xAB, 0xBC, 0x0C])
+  const unsignedValue = await cs.unsign('hello.hIvljrKw5oOZtHHSq5u+MlL27cgnPKX77y7F+x5r1to', key)
+  expect(unsignedValue).toBe('hello')
+})
+
+test('custom.sign(valueToSign, secret) should sign the cookie', async () => {
+  const custom = CookieSignature.get({ separator: '_', hash: 'sha384' })
+
+  const signed = await custom.sign('hello', 'tobiiscool')
+  expect(signed).toBe('hello_RJljN3thz3FGathvIVhUDu5T2fohzb9YVHfOB+dId9Y+JHYcQlIhSUP6WioF2sFr')
+
+  const signed2 = await custom.sign('hello', 'luna')
+  expect(signed2).not.toBe('hello_RJljN3thz3FGathvIVhUDu5T2fohzb9YVHfOB+dId9Y+JHYcQlIhSUP6WioF2sFr')
+})
+
+test('custom.sign(valueToSign, secret) should accept appropriately non-string secrets', async () => {
+  const custom = new CookieSignature({ separator: '-', hash: 'SHA512' })
+
+  const signed = await custom.sign('hello', Buffer.from('A0ABBC0C', 'hex'))
+  expect(signed).toBe('hello-TMqblNnVoVmU9HCgoYZ32oOOQHXvSY3MAHsmFaH32gl/X7uUF8pvfkj4m0wbyfGp9Sy7rmDU8C2JlSiWxxpjwA')
+
+  expect(custom.sign('unsupported', new Date())).rejects.toThrow(TypeError)
+})
+
+test('custom.unsign(signedCookieValue, secret) should unsign the cookie', async () => {
+  const custom = CookieSignature.get({ separator: '**', hash: 'SHA-1' })
+  const signed = await custom.sign('hello', 'tobiiscool')
+
+  const unsigned = await custom.unsign(signed, 'tobiiscool')
+  expect(unsigned).toBe('hello')
+
+  const unsigned2 = await custom.unsign(signed, 'luna')
+  expect(unsigned2).toBe(false)
+})
+
+test('custom.unsign(signedCookieValue, secret) should reject malformed cookies', async () => {
+  const custom = new CookieSignature({ separator: '¯\\_(ツ)_/¯', hash: 'sha256' })
+  const secret = 'actual sekrit password'
+
+  const unsigned = await custom.unsign('fake unsigned data', secret)
+  expect(unsigned).toBe(false)
+
+  const signed = await custom.sign('real data', secret)
+  const unsigned2 = await custom.unsign('garbage' + signed, secret)
+  expect(unsigned2).toBe(false)
+
+  const unsigned3 = await custom.unsign('garbage.' + signed, secret)
+  expect(unsigned3).toBe(false)
+
+  const unsigned4 = await custom.unsign(signed + '.garbage', secret)
+  expect(unsigned4).toBe(false)
+
+  const unsigned5 = await custom.unsign(signed + 'garbage', secret)
+  expect(unsigned5).toBe(false)
+})
+
+test('custom.unsign(signedCookieValue, secret) should accept non-string secrets', async () => {
+  const custom = CookieSignature.get({ separator: '**', hash: 'SHA-256' })
+  const key = Uint8Array.from([0xA0, 0xAB, 0xBC, 0x0C])
+  const unsignedValue = await custom.unsign('hello**hIvljrKw5oOZtHHSq5u+MlL27cgnPKX77y7F+x5r1to', key)
+  expect(unsignedValue).toBe('hello')
+})
+
+test('sign(valueToSign, secret) requires valueToSign to be a string', async () => {
+  expect(cs.sign(123, 'secret')).rejects.toThrow(TypeError)
+  expect(cs.sign(123, 'secret')).rejects.toThrow('Cookie value must be provided as a string.')
+})
+
+test('sign(valueToSign, secret) requires secret to be defined', async () => {
+  expect(cs.sign('hello')).rejects.toThrow(TypeError)
+  expect(cs.sign('hello')).rejects.toThrow('Secret key must be provided.')
+
+  expect(cs.sign('hello', null)).rejects.toThrow(TypeError)
+  expect(cs.sign('hello', null)).rejects.toThrow('Secret key must be provided.')
+})
+
+test('unsign(signedCookieValue, secret) requires signedCookieValue to be a string', async () => {
+  expect(cs.unsign(123, 'secret')).rejects.toThrow(TypeError)
+  expect(cs.unsign(123, 'secret')).rejects.toThrow('Signed cookie string must be provided.')
+})
+
+test('unsign(signedCookieValue, secret) requires secret to be defined', async () => {
+  expect(cs.unsign('hello')).rejects.toThrow(TypeError)
+  expect(cs.unsign('hello')).rejects.toThrow('Secret key must be provided.')
+
+  expect(cs.unsign('hello', null)).rejects.toThrow(TypeError)
+  expect(cs.unsign('hello', null)).rejects.toThrow('Secret key must be provided.')
+})
+
+test('custom ignores invalid hash option', () => {
+  const custom = new CookieSignature({ hash: 'x' })
+  expect(custom.hash).toBe('SHA-256')
+})
+
+test('custom ignores non-string separator option', () => {
+  const custom = new CookieSignature({ separator: new Date() })
+  expect(custom.separator).toBe('.')
+})

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,32 @@
+export type HashAlgorithm =
+  | 'SHA-1' | 'SHA1' | 'sha1'
+  | 'SHA-256' | 'SHA256' | 'sha256'
+  | 'SHA-384' | 'SHA384' | 'sha384'
+  | 'SHA-512' | 'SHA512' | 'sha512'
+
+export interface CookieSignatureOptions {
+  separator?: string
+  hash?: HashAlgorithm
+}
+
+export function normalizeHashAlgo(hash: string): string | undefined
+export function encoded(str: string): Uint8Array
+export function ab2str(buf: ArrayBuffer): string
+export function str2ab(str: string): ArrayBuffer
+export function secretToHmacKey(
+  secret: string | BufferSource,
+  hash: string,
+  crypto?: Crypto
+): Promise<CryptoKey>
+
+export class CookieSignature {
+  static get(opts?: CookieSignatureOptions): CookieSignature
+  constructor(opts?: CookieSignatureOptions)
+  separator: string
+  hash: string
+  sign(valueToSign: string, secret: string | BufferSource): Promise<string>
+  unsign(signedCookieValue: string, secret: string | BufferSource): Promise<string | false>
+}
+
+declare const defaultInstance: CookieSignature
+export default defaultInstance

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
   },
   "homepage": "https://github.com/nexdrew/cookie-signature-subtle#readme",
   "devDependencies": {
-    "ava": "^5.3.1",
-    "c8": "^8.0.1",
+    "ava": "^6.4.1",
+    "c8": "^10.1.3",
     "standard": "^17.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,11 +4,14 @@
   "description": "Sign and unsign cookies using web standard SubtleCrypto (browser-compatible)",
   "type": "module",
   "main": "index.js",
+  "types": "index.d.ts",
   "files": [
-    "index.js"
+    "index.js",
+    "index.d.ts"
   ],
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20.0.0",
+    "bun": ">=1.1.0"
   },
   "scripts": {
     "lint": "standard",


### PR DESCRIPTION
Mainly for Bun support.

Also includes:
- New CI job to test on Bun 1.x (that is compatible with existing `ava` tests)
- Upgrade ava and c8 dev dependencies to latest
- Update the release-please.yml workflow to use non-deprecated release-please and to support auto-publishing to npm